### PR TITLE
Refactor: format time with f-strings instead of the add_0 function

### DIFF
--- a/src/text.py
+++ b/src/text.py
@@ -233,16 +233,10 @@ class HighscoreText(Text):
 
     @staticmethod
     def reformat_time(miliseconds):
-        def add_0(num):
-            if len(str(num)) == 1:
-                return f"0{num}"
-            else:
-                return f"{num}"
-
         seconds = miliseconds // 1000
-        str_seconds = add_0(str(seconds % 60))
-        str_minutes = add_0(str(seconds // 60))
-        return f"{str_minutes}:{str_seconds}"
+        minutes = seconds // 60
+        seconds = seconds % 60
+        return f"{minutes:02d}:{seconds:02d}"
 
 
 class AchievementText(Text):

--- a/src/timer.py
+++ b/src/timer.py
@@ -10,16 +10,10 @@ def count_up():
     minutes_ = dynamic_time // 1000 // 60 % 60
     hours_ = dynamic_time // 1000 // 60 // 60
 
-    def add_0(num):
-        if len(str(num)) == 1:
-            return f"0{num}"
-        else:
-            return f"{num}"
-
     if gv.is_timer_running:
-        gv.seconds = add_0(seconds_)
-        gv.minutes = add_0(minutes_)
-        gv.hours = add_0(hours_)
+        gv.seconds = f"{seconds_:02d}"
+        gv.minutes = f"{minutes_:02d}"
+        gv.hours = f"{hours_:02d}"
         gv.lapped_time = dynamic_time
 
 


### PR DESCRIPTION
I refactored timer.py and text.py. I removed a few lines of duplicated code as a nice side-effect.

It's an easy old issue, so I didn't ask to be assigned. I admit, it also helps with my late Hacktoberfest start. :sweat_smile:

Closes #57